### PR TITLE
test: Add intentional validation errors to test mint validate

### DIFF
--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -14,8 +14,8 @@ This page shows how to create, configure, and manage line plots in a [workspace]
 </Frame>
 
 <Tip>
-For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infrastructure, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For details, see [Visualize CoreWeave infrastructure alerts](/models/runs#visualize-coreweave-infrastructure-alerts).
-</Tip>
+For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infrastructure, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For details, see [Visualize CoreWeave infrastructure alerts](/models/runs#visualize-coreweave-infrastructure-alerts) and [this broken link](/nonexistent/page.mdx).
+<!-- Tip component not properly closed - missing closing tag
 
 ## Add a line plot
 

--- a/test-validation-errors.mdx
+++ b/test-validation-errors.mdx
@@ -1,0 +1,57 @@
+---
+title: Test validation errors
+description: This file intentionally contains errors for testing mint validate
+# Missing closing quotes and invalid YAML syntax
+broken: "unclosed quote
+---
+
+# Test file with intentional validation errors
+
+This file contains various types of errors that `mint validate` should catch.
+
+## Unclosed JSX component
+
+<Note>
+This note component is not properly closed
+
+## Invalid component syntax
+
+<Tip title="Broken tip
+Missing closing bracket and quote
+
+## Broken internal link
+
+Check out our [nonexistent page](/this/path/does/not/exist.mdx) for more info.
+
+## Malformed code block
+
+```python
+def broken_function():
+    print("This code block is missing closing backticks
+
+## Unclosed emphasis
+
+This has *unclosed emphasis that continues forever
+
+## Invalid nested components
+
+<Accordion title="Broken accordion">
+  <Note>
+    Nested component without proper closing
+  </Accordion>
+</Note>
+
+## HTML-style comment without closing
+
+<!-- This comment is never closed
+
+## Double opening tag
+
+<Card>
+<Card>
+Only one closing tag
+</Card>
+
+## Reference to invalid snippet
+
+<Snippet file="this-snippet-does-not-exist.mdx" />


### PR DESCRIPTION
## Description
This commit introduces various types of errors that mint validate should catch:

New file (test-validation-errors.mdx):
- Malformed YAML frontmatter (unclosed quotes)
- Unclosed JSX components (Note, Tip, Accordion)
- Broken internal links
- Missing closing backticks in code blocks
- Unclosed emphasis markdown
- Invalid nested components
- Unclosed HTML comments
- Invalid component nesting
- Reference to non-existent snippet

Modified file (line-plot.mdx):
- Unclosed Tip component
- Broken internal link to non-existent page

